### PR TITLE
Fixed CS remaining low after transfer complete

### DIFF
--- a/spi.c
+++ b/spi.c
@@ -171,6 +171,7 @@ static PyObject* transfer(PyObject* self, PyObject* arg)
 		.delay_usecs = delay,
 		.speed_hz = speed,
 		.bits_per_word = bits,
+                .cs_change = 1,
 	};
 
 	ret = ioctl(fd, SPI_IOC_MESSAGE(1), &tr);


### PR DESCRIPTION
Added cs_change = 1 to the transfer structure- this tells the SPI peripheral to release CS after transfer is complete, which is good practice to prevent spurious writes to the slave.
