### PR TITLE
added commonly expected meta-data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,15 @@
 from distutils.core import setup, Extension
- 
+
 module1 = Extension('spi', sources = ['spi.c'])
- 
-setup (name = 'PackageName',
-        version = '1.0',
-        description = 'This is a demo package',
-        ext_modules = [module1])
+
+setup (
+    name = 'SPI-Py',
+    author='Louis Thiery',
+    url='https://github.com/lthiery/SPI-Py',
+    download_url='https://github.com/lthiery/SPI-Py/archive/master.zip',
+    version = '1.0',
+    description = 'SPI-Py: Hardware SPI as a C Extension for Python',
+    license='GPL-v2',
+    platforms=['Linux'],
+    ext_modules = [module1]
+)


### PR DESCRIPTION
Hi Louis,

I've made some minor changes in setup.py in order to replace default values by more meaningful ones. This fixes for instance the creation of the file PackageName-1.0-py2.7.egg-info when running "setup.py install" instead of something more appropriate such as "SPI_Py-1.0-py2.7.egg-info".

I've also added a couple of meta-data in setup.py to conform a bit more to expected content.

Best regards.

Eric
