### PR TITLE
Fixed bug that prevented SPI transmissions larger than 255 bytes.

### DIFF
--- a/spi.c
+++ b/spi.c
@@ -149,7 +149,7 @@ static PyObject* transfer(PyObject* self, PyObject* arg)
 	uint8_t rx[tupleSize];
 	PyObject* tempItem;
 
-	uint8_t i=0;
+	uint16_t i=0;
 
 	while(i < tupleSize)
 	{


### PR DESCRIPTION
Fixed a bug that prevented SPI transmissions larger than 255 bytes. The i variable was uint8_t, changing it to a uint16_t solves the issue.
